### PR TITLE
set titleLabel empty

### DIFF
--- a/Classes/KYShutterButton.swift
+++ b/Classes/KYShutterButton.swift
@@ -278,6 +278,10 @@ public class KYShutterButton: UIButton {
         }
     }
     
+    public override func setTitle(title: String?, forState state: UIControlState) {
+        super.setTitle("", forState: state)
+    }
+    
     /**************************************************************************/
     // MARK: - Method
     /**************************************************************************/


### PR DESCRIPTION
Hi, I using KYShutterButton in private ios development.
titleLabel is set behind KYShutterButton. so I'll set TitleLabel empty.
